### PR TITLE
Prototype trusted types implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   },
   "devDependencies": {
     "@types/node": "20.0.0",
+    "@types/trusted-types": "^2.0.7",
     "chai": "^4.3.10",
     "chai-dom": "^1.12.0",
     "eslint": "^8.56.0",

--- a/src/htmx.js
+++ b/src/htmx.js
@@ -1,6 +1,40 @@
 var htmx = (function() {
   'use strict'
 
+  var trustedTypesAPI
+  if (trustedTypes) {
+    trustedTypesAPI = trustedTypes
+  } else {
+    // @ts-ignore
+    trustedTypesAPI = {
+      createPolicy: function(_, options) {
+        return options
+      },
+      getAttributeType() {
+        return ''
+      }
+    }
+  }
+
+  const htmxPolicy = trustedTypesAPI.createPolicy('htmx', {
+    createHTML: (s) => s,
+    createScript: (s) => s,
+    createScriptURL: (s) => s
+  })
+
+  function setAttribute(target, attr) {
+    var type = trustedTypesAPI.getAttributeType(target.tagName, attr.name)
+    if (type === 'TrustedHTML') {
+      target.setAttribute(attr.name, htmxPolicy.createHTML(attr.value))
+    } else if (type === 'TrustedScript') {
+      target.setAttribute(attr.name, htmxPolicy.createScript(attr.value))
+    } else if (type === 'TrustedScriptURL') {
+      target.setAttribute(attr.name, htmxPolicy.createScriptURL(attr.value))
+    } else {
+      target.setAttribute(attr.name, attr.value)
+    }
+  }
+
   // Public API
   const htmx = {
     // Tsc madness here, assigning the functions directly results in an invalid TypeScript output, but reassigning is fine
@@ -510,7 +544,7 @@ var htmx = (function() {
    */
   function parseHTML(resp) {
     const parser = new DOMParser()
-    return parser.parseFromString(resp, 'text/html')
+    return parser.parseFromString(htmxPolicy.createHTML(resp), 'text/html')
   }
 
   /**
@@ -530,9 +564,9 @@ var htmx = (function() {
   function duplicateScript(script) {
     const newScript = getDocument().createElement('script')
     forEach(script.attributes, function(attr) {
-      newScript.setAttribute(attr.name, attr.value)
+      setAttribute(newScript, attr)
     })
-    newScript.textContent = script.textContent
+    newScript.textContent = htmxPolicy.createScript(script.textContent)
     newScript.async = false
     if (htmx.config.inlineScriptNonce) {
       newScript.nonce = htmx.config.inlineScriptNonce
@@ -1419,7 +1453,7 @@ var htmx = (function() {
     })
     forEach(mergeFrom.attributes, function(attr) {
       if (shouldSettleAttribute(attr.name)) {
-        mergeTo.setAttribute(attr.name, attr.value)
+        setAttribute(mergeTo, attr)
       }
     })
   }
@@ -2130,7 +2164,7 @@ var htmx = (function() {
             conditionalSource += ')})'
             try {
               const conditionFunction = maybeEval(elt, function() {
-                return Function(conditionalSource)()
+                return Function(htmxPolicy.createScript(conditionalSource))()
               },
               function() { return true })
               conditionFunction.source = conditionalSource
@@ -2841,7 +2875,9 @@ var htmx = (function() {
           return
         }
         if (!func) {
-          func = new Function('event', code)
+          // TODO: This won't actually work in Chromium atm due to a bug with Trusted Types implementation
+          // You'd have to use eval instead. See https://github.com/angular/angular/blob/3bfba7ec1530d451f53e5d85516a33400550bbb3/packages/core/src/util/security/trusted_types.ts#L119
+          func = new Function('event', htmxPolicy.createScript(code))
         }
         func.call(elt, e)
       })
@@ -3837,7 +3873,7 @@ var htmx = (function() {
       }
       let varsValues
       if (evaluateValue) {
-        varsValues = maybeEval(elt, function() { return Function('return (' + str + ')')() }, {})
+        varsValues = maybeEval(elt, function() { return Function(htmxPolicy.createScript('return (' + str + ')'))() }, {})
       } else {
         varsValues = parseJSON(str)
       }
@@ -4666,7 +4702,7 @@ var htmx = (function() {
     if (title) {
       const titleElt = find('title')
       if (titleElt) {
-        titleElt.innerHTML = title
+        titleElt.textContent = title
       } else {
         window.document.title = title
       }
@@ -5017,11 +5053,11 @@ var htmx = (function() {
     if (htmx.config.includeIndicatorStyles !== false) {
       const nonceAttribute = htmx.config.inlineStyleNonce ? ` nonce="${htmx.config.inlineStyleNonce}"` : ''
       getDocument().head.insertAdjacentHTML('beforeend',
-        '<style' + nonceAttribute + '>\
+        htmxPolicy.createHTML('<style' + nonceAttribute + '>\
       .' + htmx.config.indicatorClass + '{opacity:0}\
       .' + htmx.config.requestClass + ' .' + htmx.config.indicatorClass + '{opacity:1; transition: opacity 200ms ease-in;}\
       .' + htmx.config.requestClass + '.' + htmx.config.indicatorClass + '{opacity:1; transition: opacity 200ms ease-in;}\
-      </style>')
+      </style>'))
     }
   }
 


### PR DESCRIPTION
## Description

PR on fork so it doesn't add noise to main repo.

TLDR this demonstrates roughly what changes would be needed to make HTMX [trusted types](https://developer.mozilla.org/en-US/docs/Web/API/Trusted_Types_API) compliant.

Also the policies currently just pass through the string, it would need to be thought out whether any of these sinks are being passed untrusted data from the front end that should maybe be passed through an actual policy with some sanitising.

Corresponding issue:

## Testing
*Please explain how you tested this change manually, and, if applicable, what new tests you added. If
you're making a change to just the website, you can omit this section.*

## Checklist

* [ ] I have read the contribution guidelines
* [ ] I have targeted this PR against the correct branch (`master` for website changes, `dev` for
  source changes)
* [ ] This is either a bugfix, a documentation update, or a new feature that has been explicitly
  approved via an issue
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
